### PR TITLE
Added markdown viewer

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,8 @@
   {:extra-deps
    {org.clojure/clojurescript {:mvn/version "1.10.758"}
     reagent {:mvn/version "0.9.1"}
-    lambdaisland/deep-diff2 {:mvn/version "2.0.0-93"}}}
+    lambdaisland/deep-diff2 {:mvn/version "2.0.0-93"}
+    markdown-clj {:mvn/version "1.10.5"}}}
   :shadow-cljs {:extra-deps
                 {thheller/shadow-cljs {:mvn/version "2.9.10"}}
                 :main-opts ["-m" "shadow.cljs.devtools.cli"]}

--- a/src/portal/core.cljs
+++ b/src/portal/core.cljs
@@ -7,7 +7,8 @@
             [portal.diff :as d]
             [clojure.spec.alpha :as spec]
             [clojure.string :as str]
-            [cognitect.transit :as t]))
+            [cognitect.transit :as t]
+            [markdown.core :refer [md->html]]))
 
 (defn index-value
   ([value]
@@ -195,13 +196,17 @@
      :border (str "1px solid " (::c/border settings))}}
    value])
 
+(defn inspect-markdown [settings value]
+  [inspect-html settings (md->html value)])
+
 (def viewers
-  {:portal.viewer/map    {:predicate map?          :component ins/inspect-map}
-   :portal.viewer/coll   {:predicate coll?         :component ins/inspect-coll}
-   :portal.viewer/table  {:predicate table-view?   :component inspect-table}
-   :portal.viewer/text   {:predicate string?       :component inspect-text}
-   :portal.viewer/html   {:predicate string?       :component inspect-html}
-   :portal.viewer/diff   {:predicate d/can-view?   :component d/inspect-diff}
+  {:portal.viewer/map      {:predicate map?          :component ins/inspect-map}
+   :portal.viewer/coll     {:predicate coll?         :component ins/inspect-coll}
+   :portal.viewer/table    {:predicate table-view?   :component inspect-table}
+   :portal.viewer/text     {:predicate string?       :component inspect-text}
+   :portal.viewer/html     {:predicate string?       :component inspect-html}
+   :portal.viewer/diff     {:predicate d/can-view?   :component d/inspect-diff}
+   :portal.viewer/markdown {:predicate string?       :component inspect-markdown}
    ;:portal.viewer/http   {:predicate http-request? :component inspect-http}
    })
 


### PR DESCRIPTION
Created a markdown viewer component based on the existing HTML viewer using [markdown-clj](https://github.com/yogthos/markdown-clj) as the markdown to HTML parser.