### PR TITLE
Make values limit configurable

### DIFF
--- a/src/portal/runtime.cljc
+++ b/src/portal/runtime.cljc
@@ -23,7 +23,8 @@
   (get @instance-cache [:uuid uuid]))
 
 (defonce state (atom {:portal/state-id (random-uuid)
-                      :portal/value (list)}))
+                      :portal/value (list)
+                      :portal.values/limit 25}))
 
 (defn update-setting [k v] (swap! state assoc k v) true)
 
@@ -50,7 +51,7 @@
    (done nil)))
 
 (defn limit-values [state]
-  (update state :portal/value #(take 25 %)))
+  (update state :portal/value #(take (:portal.values/limit state) %)))
 
 (defn load-state [request done]
   (let [state-value @state


### PR DESCRIPTION
Thanks for the awesome app.

I am trying to use Portal as ui for showing postgresql logs: https://github.com/nenadalm/postgresql-log-viewer#postgresql-log-viewer. Usually I want to see all queries formatted including parameters (they are separate to the sql query string in the log), so that I can just copy-paste the query I choose and run it (possibly because it is slow, incorrect, ...).

These queries are usually invoked during some http request.

Some apps I work with have way more than 25 quries per http request though, so it would be nice if I could somehow change this limit of 25 values.

This pr allows setting this limit to arbitrary value when opening portal.