### PR TITLE
Add option to "reopen" closed portal session

### DIFF
--- a/src/portal/api.cljc
+++ b/src/portal/api.cljc
@@ -16,10 +16,13 @@
   (l/start options))
 
 (defn open
-  "Open a new inspector window."
+  "Open a new inspector window. A previous instance can be passed as
+  parameter to make sure it is open."
   ([] (open nil))
-  ([options]
-   (l/open options)))
+  ([portal-or-options]
+   (if (:session-id portal-or-options)
+     (l/open portal-or-options nil)
+     (l/open nil portal-or-options))))
 
 (defn close
   "Close all current inspector windows."

--- a/src/portal/runtime/jvm/client.clj
+++ b/src/portal/runtime/jvm/client.clj
@@ -72,3 +72,6 @@
   (print-method (into {} portal) w))
 
 (defn make-atom [session-id] (Portal. session-id))
+
+(defn open? [session-id]
+  (get @sessions session-id))

--- a/src/portal/runtime/node/client.cljs
+++ b/src/portal/runtime/node/client.cljs
@@ -31,3 +31,6 @@
                     {:session-id session-id :message message}))))
 
 (defn make-atom [_session-id])
+
+(defn open? [session-id]
+  (get @sessions session-id))


### PR DESCRIPTION
Adding a new parameter to `portal.api/open` function that accepts a portal instance. If the instance is closed, a new one with the same session id is open. If the instance is still open, the function does nothing.

This can be useful for tooling built on top of portal since it does not need to keep track whether the browser window is open or not. A use case for that is integrating portal with org [babel](https://orgmode.org/worg/org-contrib/babel/).

TODO:

- [x] Implement for node runtime
- [x] Implement for web runtime
- [ ] ?Add `portal` parameter to `api/close` and `api/clear` functions?
- [x] Update docs