### PR TITLE
Fixed hex color regex, added material-ui theme

### DIFF
--- a/src/portal/colors.cljc
+++ b/src/portal/colors.cljc
@@ -51,5 +51,22 @@
     ::package "#2aa198"
     ::exception "#dc322f"
     ::diff-add "#859900"
-    ::diff-remove "#dc322f"}})
+    ::diff-remove "#dc322f"}
+   ::material-ui
+   {::text "#d8dee9"
+    ::background "#2c2d3b"
+    ::background2 "#21232f"
+    ::boolean "#5e81ac"
+    ::string "#c3e887"
+    ::keyword "#c792ea"
+    ::namespace "#ffb563"
+    ::tag "#ebcb8b"
+    ::symbol "#92bdec"
+    ::number "#f77669"
+    ::uri "#d08770"
+    ::border "#797979"
+    ::package "#ffb563"
+    ::exception "#bf616a"
+    ::diff-add "#a3be8c"
+    ::diff-remove "#bf616a"}})
 

--- a/src/portal/ui/commands.cljs
+++ b/src/portal/ui/commands.cljs
@@ -539,6 +539,8 @@
     :run (fn [_state] (state/set-theme! ::c/solarized-light))}
    {:name :portal.command/theme-nord
     :run (fn [_state] (state/set-theme! ::c/nord))}
+   {:name :portal.command/theme-material-ui
+    :run (fn [_state] (state/set-theme! ::c/material-ui))}
    {:name :portal.command/copy-as-edn
     ::shortcuts/osx #{"meta" "c"}
     ::shortcuts/default #{"control" "c"}

--- a/src/portal/ui/inspector.cljs
+++ b/src/portal/ui/inspector.cljs
@@ -362,7 +362,7 @@
     [s/span {:style {:color (::c/number theme)}} value]))
 
 (defn hex-color? [string]
-  (re-matches #"#[0-9a-f]{6}|#[0-9a-f]{3}gi" string))
+  (re-matches #"#[0-9a-fA-F]{6}|#[0-9a-fA-F]{3}gi" string))
 
 (defn- url-string? [string]
   (re-matches #"https?://.*" string))


### PR DESCRIPTION
- Regex for hex forgot to include uppercase characters, so that is resolved
- Added an initial material-ui theme base + command to switch