### PR TITLE
Make :field optional in vega lite spec

### DIFF
--- a/src/portal/ui/viewer/vega_lite.cljs
+++ b/src/portal/ui/viewer/vega_lite.cljs
@@ -13,8 +13,7 @@
            :opt-un [::type ::title ::axis]))
 
 (sp/def ::y
-  (sp/keys :req-un [::field]
-           :opt-un [::type ::title ::axis]))
+  (sp/key :opt-un [::field ::type ::title ::axis]))
 
 (sp/def ::encoding
   (sp/keys :opt-un [::x ::y ::theta]))

--- a/src/portal/ui/viewer/vega_lite.cljs
+++ b/src/portal/ui/viewer/vega_lite.cljs
@@ -13,7 +13,7 @@
            :opt-un [::type ::title ::axis]))
 
 (sp/def ::y
-  (sp/key :opt-un [::field ::type ::title ::axis]))
+  (sp/keys :opt-un [::field ::type ::title ::axis]))
 
 (sp/def ::encoding
   (sp/keys :opt-un [::x ::y ::theta]))


### PR DESCRIPTION
`:field` can be omitted when doing things like histograms (e.g. https://vega.github.io/vega-lite/docs/bin.html#histogram). At the moment is possible to workaround this by setting `:field` to a random value, but it took me a long time to figure out why the chart didn't render. I'm not sure if `:field` should also be made optional for `:x`.