### PR TITLE
Manage multiple project instances on IntelliJ extension

### DIFF
--- a/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
+++ b/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
@@ -40,8 +40,8 @@
 
 (defn init-options [browser]
   (run-js browser
-   (str
-    "sessionStorage.setItem(\"PORTAL_EXTENSION_OPTIONS\", " (get-options) ")")))
+          (str
+           "sessionStorage.setItem(\"PORTAL_EXTENSION_OPTIONS\", " (get-options) ")")))
 
 (defn patch-options
   ([]
@@ -50,7 +50,7 @@
   ([browser]
    (init-options browser)
    (run-js browser
-     (str "portal.ui.options.patch(" (get-options) ")"))))
+           (str "portal.ui.options.patch(" (get-options) ")"))))
 
 (defn -uiSettingsChanged  [_this _] (patch-options))
 (defn -globalSchemeChange [_this _] (patch-options))
@@ -74,10 +74,10 @@
 
 (defn start [^Project project]
   (swap! instances update project
-    (fn [m]
-      (cond-> m
-        (not (:server m))
-        (assoc :server (http/run-server #(handler % project) {:port 0 :legacy-return-value? false})))))
+         (fn [m]
+           (cond-> m
+             (not (:server m))
+             (assoc :server (http/run-server #(handler % project) {:port 0 :legacy-return-value? false})))))
   (write-config
    project
    {:host "localhost"

--- a/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
+++ b/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
@@ -20,15 +20,15 @@
                 com.intellij.openapi.wm.ToolWindowFactory]
    :name portal.extensions.intellij.Factory))
 
-(defonce ^:private browser (atom nil))
-(defonce ^:private proj    (atom nil))
-(defonce ^:private server  (atom nil))
+; instances are indexed per project, each instance will contain the keys
+; :browser and :server
+(defonce ^:private instances (atom {}))
 
 (defn- format-url [{:keys [portal server]}]
   (str "http://" (:host server) ":" (:port server) "?" (:session-id portal)))
 
-(defn- run-js [^String js]
-  (when-let [^JBCefBrowser browser @browser]
+(defn- run-js [^JBCefBrowser browser ^String js]
+  (when browser
     (.executeJavaScript (.getCefBrowser browser) js "" 0)))
 
 (defn- get-options []
@@ -38,27 +38,32 @@
      :themes
      {::theme (theme/get-theme)}})))
 
-(defn init-options []
-  (run-js
+(defn init-options [browser]
+  (run-js browser
    (str
     "sessionStorage.setItem(\"PORTAL_EXTENSION_OPTIONS\", " (get-options) ")")))
 
-(defn patch-options []
-  (init-options)
-  (run-js
-   (str "portal.ui.options.patch(" (get-options) ")")))
+(defn patch-options
+  ([]
+   (doseq [browser (into [] (map :browser) (vals @instances))]
+     (patch-options browser)))
+  ([browser]
+   (init-options browser)
+   (run-js browser
+     (str "portal.ui.options.patch(" (get-options) ")"))))
 
 (defn -uiSettingsChanged  [_this _] (patch-options))
 (defn -globalSchemeChange [_this _] (patch-options))
 
-(defn handler [request]
-  (let [body (edn/read (PushbackReader. (io/reader (:body request))))]
+(defn handler [request project]
+  (let [body (edn/read (PushbackReader. (io/reader (:body request))))
+        browser (get-in @instances [project :browser])]
     (case (:uri request)
       "/open"
-      (do (init-options)
-          (.loadURL ^JBCefBrowser @browser (format-url body))
+      (do (init-options browser)
+          (.loadURL ^JBCefBrowser browser (format-url body))
           {:status 200})
-      "/open-file" (do (file/open @proj body) {:status 200})
+      "/open-file" (do (file/open project body) {:status 200})
       {:status 404})))
 
 (defn- write-config [^Project project config]
@@ -68,18 +73,20 @@
     (spit file (pr-str config))))
 
 (defn start [^Project project]
-  (when-not @server
-    (reset! server (http/run-server #'handler {:port 0 :legacy-return-value? false})))
+  (swap! instances update project
+    (fn [m]
+      (cond-> m
+        (not (:server m))
+        (assoc :server (http/run-server #(handler % project) {:port 0 :legacy-return-value? false})))))
   (write-config
    project
    {:host "localhost"
-    :port (http/server-port @server)}))
+    :port (http/server-port (get-in @instances [project :server]))}))
 
 (defn- get-window ^JComponent [^Project project]
   (start project)
-  (reset! proj project)
   (let [b (JBCefBrowser.)]
-    (reset! browser b)
+    (swap! instances assoc-in [project :browser] b)
     (Disposer/register project b)
     (.getComponent b)))
 


### PR DESCRIPTION
Hello, I decide to try a take to fix the multi-project issues.

I notice the previous code was with the expectation of a single project getting managed, I switched that to a map managing multiple projects.

I just finished coding this, I think would be nice to try it better for a few days (although I could see the issues fixed on my initial tests here :)).