### PR TITLE
Use metadata to specify custom table sort

### DIFF
--- a/src/portal/ui/viewer/table.cljs
+++ b/src/portal/ui/viewer/table.cljs
@@ -98,7 +98,7 @@
 
 (defn- inspect-map-table [values]
   (let [rows (seq (ins/try-sort (keys values)))
-        cols (or (:portal.viewer.table/columns (meta values))
+        cols (or (get-in (meta values) [:portal.viewer/table :columns])
                  (seq (ins/try-sort (into #{} (mapcat keys (vals values))))))]
     [table
      [columns cols]
@@ -126,7 +126,7 @@
 
 (defn- inspect-coll-table [values]
   (let [rows (seq values)
-        cols (or (:portal.viewer.table/columns (meta values))
+        cols (or (get-in (meta values) [:portal.viewer/table :columns])
                  (seq (ins/try-sort (into #{} (mapcat keys values)))))]
     [table
      [columns cols]

--- a/src/portal/ui/viewer/table.cljs
+++ b/src/portal/ui/viewer/table.cljs
@@ -98,7 +98,8 @@
 
 (defn- inspect-map-table [values]
   (let [rows (seq (ins/try-sort (keys values)))
-        cols (seq (ins/try-sort (into #{} (mapcat keys (vals values)))))]
+        cols (or (:portal.viewer.table/columns (meta values))
+                 (seq (ins/try-sort (into #{} (mapcat keys (vals values))))))]
     [table
      [columns cols]
      [l/lazy-seq
@@ -125,7 +126,8 @@
 
 (defn- inspect-coll-table [values]
   (let [rows (seq values)
-        cols (seq (ins/try-sort (into #{} (mapcat keys values))))]
+        cols (or (:portal.viewer.table/columns (meta values))
+                 (seq (ins/try-sort (into #{} (mapcat keys values)))))]
     [table
      [columns cols]
      [l/lazy-seq


### PR DESCRIPTION
Allow users to custom sort table viewer columns using metadata on a value. If the value is not available in the metadata current behavior is the default. Open to a different namespaced key for this option!

Example usage:
```Clojure
(tap> (with-meta [{:a 1} {:b 2}] {:portal.viewer/table {:columns [:b :a]}}))
```