### PR TITLE
Add :on-load option for p/open

### DIFF
--- a/src/portal/runtime/jvm/server.clj
+++ b/src/portal/runtime/jvm/server.clj
@@ -56,7 +56,9 @@
                                :op :portal.rpc/response)))))))
       :on-open
       (fn [ch]
-        (swap! c/connections assoc (:session-id session) (partial send! ch)))
+        (swap! c/connections assoc (:session-id session) (partial send! ch))
+        (when-let [f (get-in session [:options :on-load])]
+          (f)))
       :on-close
       (fn [_ch _status]
         (swap! c/connections dissoc (:session-id session)))})))

--- a/src/portal/runtime/node/server.cljs
+++ b/src/portal/runtime/node/server.cljs
@@ -58,6 +58,8 @@
              (fn send! [message]
                (.send ws (rt/write message session)))]
          (swap! c/connections assoc (:session-id session) send!)
+         (when-let [f (get-in session [:options :on-load])]
+           (f))
          (.on ws "message"
               (fn [message]
                 (a/let [req  (rt/read message session)

--- a/test/portal/e2e.clj
+++ b/test/portal/e2e.clj
@@ -12,6 +12,7 @@
 (defn options []
   {:app          (rand-nth [true false])
    :theme        (rand-nth (keys (dissoc c/themes ::c/vs-code-embedded)))
+   :on-load      '(fn [] (tap> :loaded!))
    :window-title (rand-nth pane-titles)})
 
 (defn -main [& args]
@@ -20,7 +21,6 @@
     (step '(require '[portal.api :as p])))
   (step `(do (add-tap #'p/submit)
              (p/open ~(options))))
-  (step '(tap> :hello-world))
   (step '(p/clear))
   (step '(require '[examples.data :refer [data]]))
   (step '(tap> data))


### PR DESCRIPTION
Add an option to run an arbitrary function once portal is loaded. 

Usage:
```clojure
(portal.api/open {:on-load (fn [] (portal.api/eval-str "(js/alert 1)"))})
```