### PR TITLE
IJ Plugin - Implements the `DumbAware` marker interface

### DIFF
--- a/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
+++ b/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
@@ -17,7 +17,8 @@
    :extends portal.extensions.intellij.WithLoader
    :implements [com.intellij.ide.ui.UISettingsListener
                 com.intellij.openapi.editor.colors.EditorColorsListener
-                com.intellij.openapi.wm.ToolWindowFactory]
+                com.intellij.openapi.wm.ToolWindowFactory
+                com.intellij.openapi.project.DumbAware]
    :name portal.extensions.intellij.Factory))
 
 ; instances are indexed per project, each instance will contain the keys


### PR DESCRIPTION
This should prevent the tool window from blanking and becoming unusable while reindexing. Since that happens basically whenever IJ regains focus, it is a chronic issue.