### PR TITLE
IJ Plugin - Bumps until version to run through 2022

### DIFF
--- a/extension-intellij/build.gradle
+++ b/extension-intellij/build.gradle
@@ -11,6 +11,11 @@ intellij {
     version = '2021.3'
 }
 
+patchPluginXml {
+    sinceBuild = '191.*'
+    untilBuild = '221.*'
+}
+
 publishPlugin {
   token = System.getenv("JETBRAINS_TOKEN")
 }

--- a/extension-intellij/src/main/resources/META-INF/plugin.xml
+++ b/extension-intellij/src/main/resources/META-INF/plugin.xml
@@ -42,7 +42,6 @@
     </p>
 
     ]]></description>
-    <idea-version since-build="192.5118"/>
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
* Updates Gradle build file to patch the since/until versions in the plugin.xml file, rather than having them live in the source file
* Bumps the until version to work through 2022

Ran the verifier plugin, and installed the generated plugin to confirm interop with latest IJ (Build #IU-221.5080.210).

The Gradle build file could use some more attention and love, with properties pulled out and tasks better specified, but this should be sufficient for the next 9-12 months.