### PR TITLE
Fix hidden portal window in IntelliJ on Linux.

### DIFF
--- a/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
+++ b/extension-intellij/src/main/clojure/portal/extensions/intellij/factory.clj
@@ -106,4 +106,4 @@
 
 (defn -createToolWindowContent [_this ^Project project ^ToolWindow window]
   (let [component (.getComponent window)]
-    (.add (.getParent component) (get-window project))))
+    (.add component (get-window project))))


### PR DESCRIPTION
This change fixes a bug where the Portal tool window would be at least
partially hidden in IntelliJ by a "Nothing to show" message.

Details in Clojurians Slack: https://clojurians.slack.com/archives/C0185BFLLSE/p1651075065477909