### PR TITLE
update emacs elisp example to def portal to dev namespace

### DIFF
--- a/doc/editors/emacs.md
+++ b/doc/editors/emacs.md
@@ -7,10 +7,11 @@ the following section may be of interest to you.
 ;; Leverage an existing cider nrepl connection to evaluate portal.api functions
 ;; and map them to convenient key bindings.
 
+;; def portal to the dev namespace to allow dereferencing via @dev/portal
 (defun portal.api/open ()
   (interactive)
   (cider-nrepl-sync-request:eval
-   "(require 'portal.api) (portal.api/tap) (portal.api/open)"))
+    "(do (ns dev) (def portal ((requiring-resolve 'portal.api/open))) (add-tap (requiring-resolve 'portal.api/submit)))"))
 
 (defun portal.api/clear ()
   (interactive)


### PR DESCRIPTION
This is just a small doc change that was useful to me and that I thought might be useful to others as well