### PR TITLE
intellij: Use console font size

### DIFF
--- a/extension-intellij/src/main/clojure/portal/extensions/intellij/theme.clj
+++ b/extension-intellij/src/main/clojure/portal/extensions/intellij/theme.clj
@@ -81,8 +81,8 @@
    (get-font
     (.getGlobalScheme (EditorColorsManager/getInstance))))
   ([^EditorColorsScheme theme]
-   {:font-size   (.getEditorFontSize theme)
-    :font-family (str (pr-str (.getEditorFontName theme)) ", monospace")}))
+   {:font-size   (.getConsoleFontSize theme)
+    :font-family (str (pr-str (.getConsoleFontName theme)) ", monospace")}))
 
 (defn resolve-theme [m]
   (reduce-kv


### PR DESCRIPTION
This way the plugin will use the same font settings as the Cursive REPL.