### PR TITLE
Adds `Shift + Enter` shortcut for clojure.datafy/datafy

### DIFF
--- a/src/portal/ui/commands.cljs
+++ b/src/portal/ui/commands.cljs
@@ -269,6 +269,7 @@
    {::shortcuts/default #{" "}}                 `toggle-expand
 
    {::shortcuts/default #{"enter"}}             'clojure.datafy/nav
+   {::shortcuts/default #{"shift" "enter"}}     'clojure.datafy/datafy
 
    {::shortcuts/default #{"control" "r"}}       `redo-previous-command
    {::shortcuts/default #{"control" "l"}}       `clear


### PR DESCRIPTION
Fixes https://github.com/djblue/portal/issues/139.