### PR TITLE
Add ability to change initial folding for some data structure in a tree viewer

### DIFF
--- a/src/portal/ui/viewer/tree.cljs
+++ b/src/portal/ui/viewer/tree.cljs
@@ -32,8 +32,10 @@
 (defn- center [& children]
   (into [s/div {:style flex-center}] children))
 
-(defn- inspect-tree-item [opts]
-  (let [[open? set-open] (react/useState true)
+(defn- inspect-tree-item [{:keys [values] :as opts}]
+  (let [[open? set-open] (react/useState (if-some [expand (get-in (meta values) [:portal.viewer/tree :expand])]
+                                           expand
+                                           true))
         theme (theme/use-theme)
         value (:value opts)
         [open close] (delimiter value)


### PR DESCRIPTION
Is this something desired?

Another alternative would be to create something more generic like `:portal.viewer/state` where we could hook up into various viewers so the user can control initial states (or dynamic ones) from there (but it's a little bit more complex).