### PR TITLE
Remove hard-coded font name (Monaco) from themes.

### DIFF
--- a/src/portal/ui/theme.cljs
+++ b/src/portal/ui/theme.cljs
@@ -13,7 +13,7 @@
 (defn- get-theme [theme-name]
   (let [opts (opts/use-options)]
     (merge
-     {:font-family   "Monaco, monospace"
+     {:font-family   "monospace"
       :font-size     "12pt"
       :string-length 100
       :max-depth     2


### PR DESCRIPTION
This is so that Portal can respect and use the user's favorite fixed-width font set in their browsers.