### PR TITLE
Remember ViewColumn between opens

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -39,7 +39,8 @@
    {:infer-externs true
     :warnings-as-errors true}
    :output-to "extension-vscode/vs-code.js"
-   :devtools {:after-load portal.extensions.vs-code/reload}}
+   :devtools {:before-load portal.extensions.vs-code/before-load
+              :after-load portal.extensions.vs-code/after-load}}
 
   :vs-code-notebook
   {:output-dir "extension-vscode/notebook/"

--- a/src/portal/runtime/node/server.cljs
+++ b/src/portal/runtime/node/server.cljs
@@ -18,8 +18,6 @@
   (done {:status :not-found}))
 
 (defn- require-string [src file-name]
-  (println "BOOM! require-string src" src)
-  (println "BOOM! require-string file-name" file-name)
   (let [Module (js/require "module")
         ^js m (Module. file-name js/module.parent)]
     (set! (.-filename m) file-name)

--- a/src/portal/runtime/node/server.cljs
+++ b/src/portal/runtime/node/server.cljs
@@ -18,6 +18,8 @@
   (done {:status :not-found}))
 
 (defn- require-string [src file-name]
+  (println "BOOM! require-string src" src)
+  (println "BOOM! require-string file-name" file-name)
   (let [Module (js/require "module")
         ^js m (Module. file-name js/module.parent)]
     (set! (.-filename m) file-name)


### PR DESCRIPTION
* Default view column set to `ViewColumn.Beside` which I think is a better guess than `ViewColumn.One`.
* When the view state of the webview panel changes we save the current view column in extension context storage. This is read and used when opening the panel.

This makes it so that when you move the Portal view somewhere, it will be opened there next time. The Calva Output/REPL window behaves like this and people seem happy with it. =)

Fixes #160

*NB*: With this PR I also have added some hot reload infra structure for registering and deregistering disposables, so that we don't need to restart the extension host to add or remove commands, event handlers and other disposables. This is what I do in my extensions, and I thought I would add the event for saving the view column as a global disposable. But then it turned out that it was an event attached to the WebView panel instance... Let me know if you want to have a cleaner PR without this change.