### PR TITLE
[docs] update cider variable to include :portal alias

### DIFF
--- a/doc/editors/emacs.md
+++ b/doc/editors/emacs.md
@@ -30,7 +30,7 @@ the following section may be of interest to you.
 
 ;; NOTE: You do need to have portal on the class path and the easiest way I know
 ;; how is via a clj user or project alias.
-(setq cider-clojure-cli-global-options "-A:portal")
+(setq cider-clojure-cli-aliases ":portal")
 ```
 
 ## xwidget-webkit embed


### PR DESCRIPTION
`cider-clojure-cli-global-options` has been deprecated in favour of `cider-clojure-cli-aliases` circa December 2020

Resolve #171