### PR TITLE
Add toggle-expand-all command to toggle folding of nested elements

### DIFF
--- a/src/portal/ui/commands.cljs
+++ b/src/portal/ui/commands.cljs
@@ -267,6 +267,8 @@
    {::shortcuts/default #{"control" "enter"}}   `focus-selected
    {::shortcuts/default #{"e"}}                 `toggle-expand
    {::shortcuts/default #{" "}}                 `toggle-expand
+   {::shortcuts/default #{"shift" "e"}}         `toggle-expand-all
+   {::shortcuts/default #{"shift" " "}}         `toggle-expand-all
 
    {::shortcuts/default #{"enter"}}             'clojure.datafy/nav
    {::shortcuts/default #{"shift" "enter"}}     'clojure.datafy/datafy
@@ -809,6 +811,9 @@
 
 (defn ^:command toggle-expand [state]
   (state/dispatch! state state/toggle-expand))
+
+(defn ^:command toggle-expand-all [state]
+  (state/dispatch! state state/toggle-expand-all))
 
 (defn ^:command redo-previous-command [state]
   (a/let [commands (::state/previous-commands @state)]


### PR DESCRIPTION
Analog to the existing `toggle-expand` command but
`toggle-expand-all` also shows/hides all child elements.


PR Note: I couldn't find a function to extract all
child locations from the current context,
maybe there's a better/easier way than the `get-child-locations` function.