### PR TITLE
Multi selection viewer change

### DIFF
--- a/src/portal/ui/app.cljs
+++ b/src/portal/ui/app.cljs
@@ -116,7 +116,7 @@
         state (state/use-state)
         selected-context (state/get-all-selected-context @state)
         viewer           (ins/get-viewer state (first selected-context))
-        compatible-viewers (ins/get-compatible-viewers-intersection @ins/viewers selected-context)]
+        compatible-viewers (ins/get-compatible-viewers @ins/viewers selected-context)]
     [s/div
      {:style
       {:display :flex
@@ -134,7 +134,7 @@
        :value (pr-str (:name viewer))
        :on-change
        (fn [e]
-         (ins/set-viewer-contexts!
+         (ins/set-viewer!
           state
           selected-context
           (keyword (.substr (.. e -target -value) 1))))

--- a/src/portal/ui/app.cljs
+++ b/src/portal/ui/app.cljs
@@ -114,9 +114,9 @@
 (defn inspect-footer []
   (let [theme (theme/use-theme)
         state (state/use-state)
-        selected-context (state/get-selected-context @state)
-        viewer           (ins/get-viewer state selected-context)
-        compatible-viewers (ins/get-compatible-viewers @ins/viewers selected-context)]
+        selected-context (state/get-all-selected-context @state)
+        viewer           (ins/get-viewer state (first selected-context))
+        compatible-viewers (ins/get-compatible-viewers-intersection @ins/viewers selected-context)]
     [s/div
      {:style
       {:display :flex
@@ -134,7 +134,7 @@
        :value (pr-str (:name viewer))
        :on-change
        (fn [e]
-         (ins/set-viewer!
+         (ins/set-viewer-contexts!
           state
           selected-context
           (keyword (.substr (.. e -target -value) 1))))

--- a/src/portal/ui/commands.cljs
+++ b/src/portal/ui/commands.cljs
@@ -730,17 +730,17 @@
   (state/dispatch! state state/select-pop))
 
 (defn ^:command select-viewer
-  "Set the viewer for the currently selected value."
+  "Set the viewer for the currently selected value(s)."
   [state]
-  (when-let [selected-context (state/get-selected-context @state)]
-    (let [viewers (ins/get-compatible-viewers @ins/viewers selected-context)]
+  (when-let [selected-context (state/get-all-selected-context @state)]
+    (let [viewers (ins/get-compatible-viewers-intersection @ins/viewers selected-context)]
       (when (> (count viewers) 1)
         (a/let [[selected-viewer] (pick-one state (map :name viewers))]
-          (ins/set-viewer! state selected-context selected-viewer))))))
+          (ins/set-viewer-contexts! state selected-context selected-viewer))))))
 
 (defn- get-viewer [state context direction]
-  (let [viewers (map :name (ins/get-compatible-viewers @ins/viewers context))
-        current (:name (ins/get-viewer state context))]
+  (let [viewers (map :name (ins/get-compatible-viewers-intersection @ins/viewers context))
+        current (:name (ins/get-viewer state (first context)))]
     (when (> (count viewers) 1)
       (some
        (fn [[prev next]]
@@ -750,14 +750,14 @@
        (partition 2 1 (conj viewers (last viewers)))))))
 
 (defn ^:command select-prev-viewer [state]
-  (when-let [selected-context (state/get-selected-context @state)]
+  (when-let [selected-context (state/get-all-selected-context @state)]
     (when-let [prev-viewer (get-viewer state selected-context :prev)]
-      (ins/set-viewer! state selected-context prev-viewer))))
+      (ins/set-viewer-contexts! state selected-context prev-viewer))))
 
 (defn ^:command select-next-viewer [state]
-  (when-let [selected-context (state/get-selected-context @state)]
+  (when-let [selected-context (state/get-all-selected-context @state)]
     (when-let [next-viewer (get-viewer state selected-context :next)]
-      (ins/set-viewer! state selected-context next-viewer))))
+      (ins/set-viewer-contexts! state selected-context next-viewer))))
 
 (defn ^:command copy-path
   "Copy the path from the root value to the currently selected item."

--- a/src/portal/ui/commands.cljs
+++ b/src/portal/ui/commands.cljs
@@ -733,13 +733,13 @@
   "Set the viewer for the currently selected value(s)."
   [state]
   (when-let [selected-context (state/get-all-selected-context @state)]
-    (let [viewers (ins/get-compatible-viewers-intersection @ins/viewers selected-context)]
+    (let [viewers (ins/get-compatible-viewers @ins/viewers selected-context)]
       (when (> (count viewers) 1)
         (a/let [[selected-viewer] (pick-one state (map :name viewers))]
-          (ins/set-viewer-contexts! state selected-context selected-viewer))))))
+          (ins/set-viewer! state selected-context selected-viewer))))))
 
 (defn- get-viewer [state context direction]
-  (let [viewers (map :name (ins/get-compatible-viewers-intersection @ins/viewers context))
+  (let [viewers (map :name (ins/get-compatible-viewers @ins/viewers context))
         current (:name (ins/get-viewer state (first context)))]
     (when (> (count viewers) 1)
       (some
@@ -752,12 +752,12 @@
 (defn ^:command select-prev-viewer [state]
   (when-let [selected-context (state/get-all-selected-context @state)]
     (when-let [prev-viewer (get-viewer state selected-context :prev)]
-      (ins/set-viewer-contexts! state selected-context prev-viewer))))
+      (ins/set-viewer! state selected-context prev-viewer))))
 
 (defn ^:command select-next-viewer [state]
   (when-let [selected-context (state/get-all-selected-context @state)]
     (when-let [next-viewer (get-viewer state selected-context :next)]
-      (ins/set-viewer-contexts! state selected-context next-viewer))))
+      (ins/set-viewer! state selected-context next-viewer))))
 
 (defn ^:command copy-path
   "Copy the path from the root value to the currently selected item."

--- a/src/portal/ui/embed.cljs
+++ b/src/portal/ui/embed.cljs
@@ -92,8 +92,8 @@
 (defn select-viewer []
   (let [theme              (theme/use-theme)
         state              (state/use-state)
-        selected-context   (state/get-selected-context @state)
-        viewer             (ins/get-viewer state selected-context)
+        selected-context   (state/get-all-selected-context @state)
+        viewer             (ins/get-viewer state (first selected-context))
         compatible-viewers (ins/get-compatible-viewers @ins/viewers selected-context)
         disabled?          (nil? selected-context)]
     [s/div

--- a/src/portal/ui/inspector.cljs
+++ b/src/portal/ui/inspector.cljs
@@ -3,6 +3,7 @@
   (:require ["anser" :as anser]
             ["react" :as react]
             [clojure.string :as str]
+            [clojure.set :as set]
             [lambdaisland.deep-diff2.diff-impl :as diff]
             [portal.async :as a]
             [portal.colors :as c]
@@ -125,6 +126,14 @@
         viewers        (cons default-viewer (remove #(= default-viewer %) viewers))]
     (filter #(when-let [pred (:predicate %)] (pred value)) viewers)))
 
+(defn get-compatible-viewers-intersection [viewers contexts]
+  (if (nil? contexts)
+    (get-compatible-viewers viewers contexts)
+    (->> contexts
+         (map #(get-compatible-viewers viewers %))
+         (map set)
+         (apply set/intersection))))
+
 (defn get-viewer
   ([state context]
    (get-viewer state context (:value context)))
@@ -139,6 +148,10 @@
   (state/dispatch! state
                    assoc-in [:selected-viewers (state/get-location context)]
                    viewer-name))
+
+(defn set-viewer-contexts! [state contexts viewer-name]
+  (doseq [context contexts]
+    (set-viewer! state context viewer-name)))
 
 (def ^:private parent-context (react/createContext nil))
 

--- a/src/portal/ui/state.cljs
+++ b/src/portal/ui/state.cljs
@@ -50,6 +50,8 @@
 
 (defn get-selected-context [state] (first (:selected state)))
 
+(defn get-all-selected-context [state] (:selected state))
+
 (defn get-selected-value [state] (:value (get-selected-context state)))
 
 (defn selected-values [state] (map :value (:selected state)))


### PR DESCRIPTION
### Context?

Adding the ability to apply a viewer change to multiple selections at once. 

### Changes?

* Changed behavior from some functions
  * `inspector/set-viewer!`  
    * applies the viewer change for multiple selected contexts
  * `inspector/get-compatible-viewers!` 
    * Retrieves the intersection of compatible viewers from all selected contexts 
    * if nothing is selected, it returns the default viewers
* Add helper functions  
  * `state/get-all-selected-context`
    * Retrieves all the selected contexts 
* Apply the logic in two different places on the UI
  * The viewers list, on the bottom left corner
  * The viewer commands from the command pallet
    * `portal.ui.commands/select-next-viewer`
    * `portal.ui.commands/select-prev-viewer`
    * `portal.ui.commands/select-viewer `
  * The viewer commands inside the embedded portal (eg: Calva Notebooks)

### How this was tested?

It was tested on the browser and vs-code launcher