### PR TITLE
Support vega-lite :datasets key as well as :data

### DIFF
--- a/src/portal/ui/viewer/vega_lite.cljs
+++ b/src/portal/ui/viewer/vega_lite.cljs
@@ -13,7 +13,7 @@
   (s/and string? #(re-matches vega-lite-url %)))
 
 (s/def ::vega-lite
-  (s/keys :req-un [::data]
+  (s/keys :req-un [(or ::data ::datasets)]
           :opt-un [::name ::description ::$schema]))
 ;;;
 


### PR DESCRIPTION
Currently, the vega-lite viewer [requires the `data` key](https://github.com/djblue/portal/blob/b19ca345766c3821f9626eb6114853429bf90407/src/portal/ui/viewer/vega_lite.cljs#L16) in the selected value. However, the Vega-Lite specification doesn't actually require it, and the [`datasets`](https://vega.github.io/vega-lite/docs/data.html#datasets) field is sometimes useful rather than `data` (especially when you have an individual dataset for each layer).

This PR proposes to relax the current spec of the vega-lite viewer and change it so that it can accept either of the `data` or `datasets` key.