### PR TITLE
Extend multi selection

### DIFF
--- a/src/portal/api.cljc
+++ b/src/portal/api.cljc
@@ -235,3 +235,9 @@
    (open (assoc options :value value))))
 
 (register! #'inspect)
+
+(defn selected
+  "Get a sequence of all currently selected values."
+  {:added "0.49.0"}
+  [session]
+  (get-in @rt/sessions [(:session-id session) :selected]))

--- a/src/portal/runtime/clr/client.clj
+++ b/src/portal/runtime/clr/client.clj
@@ -55,7 +55,7 @@
 
 (defrecord Portal [session-id]
   IDeref
-  (deref [_this] (get-in @rt/sessions [session-id :selected]))
+  (deref [_this] (first (get-in @rt/sessions [session-id :selected])))
 
   IAtom
   (reset [_this new-value] (push-state session-id new-value))

--- a/src/portal/runtime/jvm/client.clj
+++ b/src/portal/runtime/jvm/client.clj
@@ -55,7 +55,7 @@
 
 (defrecord Portal [session-id]
   IDeref
-  (deref [_this] (get-in @rt/sessions [session-id :selected]))
+  (deref [_this] (first (get-in @rt/sessions [session-id :selected])))
 
   IAtom
   (reset [_this new-value] (push-state session-id new-value))

--- a/src/portal/runtime/node/client.cljs
+++ b/src/portal/runtime/node/client.cljs
@@ -61,7 +61,7 @@
 
 (defrecord Portal [session-id]
   IDeref
-  (-deref [_this] (get-in @rt/sessions [session-id :selected]))
+  (-deref [_this] (first (get-in @rt/sessions [session-id :selected])))
   IReset
   (-reset! [_this new-value] (push-state session-id new-value))
   ISwap

--- a/src/portal/runtime/web/client.cljs
+++ b/src/portal/runtime/web/client.cljs
@@ -22,7 +22,7 @@
 
 (deftype Portal [session-id]
   IDeref
-  (-deref [_this] (get-in @rt/sessions [session-id :selected]))
+  (-deref [_this] (first (get-in @rt/sessions [session-id :selected])))
   IReset
   (-reset! [_this new-value] (push-state session-id new-value))
   ISwap

--- a/src/portal/ui/commands.cljs
+++ b/src/portal/ui/commands.cljs
@@ -702,12 +702,18 @@
                 *print-level* 100]
         (pp/pprint value))))))
 
+(defn- selected-values [state-val]
+  (let [values (state/selected-values state-val)]
+    (if (= (count values) 1)
+      (first values)
+      values)))
+
 (defn ^:command copy
   "Copy selected value as an edn string to the clipboard."
   [state]
   (if-let [selection (not-empty (.. js/window getSelection toString))]
     (copy-to-clipboard! selection)
-    (copy-edn! (state/get-selected-value @state))))
+    (copy-edn! (selected-values @state))))
 
 (defn- pprint-json [v]
   (.stringify js/JSON v nil 2))
@@ -716,7 +722,7 @@
   "Copy selected value as a json string to the clipboard."
   [state]
   (-> @state
-      state/get-selected-value
+      selected-values
       clj->js
       pprint-json
       str/trim

--- a/src/portal/ui/state.cljs
+++ b/src/portal/ui/state.cljs
@@ -298,12 +298,12 @@
          :portal/previous-state nil
          :portal/next-state nil))))
 
-(defn- send-selected-value [_ _ state state']
-  (when (not= (get-selected-value state)
-              (get-selected-value state'))
-    (invoke 'portal.runtime/update-selected (get-selected-value state'))))
+(defn- send-selected-values [_ _ state state']
+  (when (not= (selected-values state)
+              (selected-values state'))
+    (invoke 'portal.runtime/update-selected (selected-values state'))))
 
-(add-watch state :selected #'send-selected-value)
+(add-watch state :selected #'send-selected-values)
 
 (defn nav [state context]
   (let [{:keys [collection key value]} context


### PR DESCRIPTION
ref: [slack chat](https://clojurians.slack.com/archives/C0185BFLLSE/p1697799626323009)

I often find myself in situations where I'm doing:

```clojure
;; click first arg
(def arg1 @session)
;; click second arg
(def arg2 @session)
(my-func arg1 arg2)
```

this patch is a sketch that would allow the following instead:

```clojure
;; click first arg
;; alt-click second arg
(apply my-func (p/selected session))
```

I've also extended the commands `copy`  and `copy-json` to support multi-selection. If there is only one value selected the value is not wrapped in a list to remain backwards compatible.

At this stage I'm mostly looking for feedback if this is a good approach or not.

To end I'd just like to say that I've found portal a very useful addition to my workflow. This is my first time diving into the code and I found the code to be very clear and well structured. Kudos!
