### PR TITLE
JWT viwer, show nbf as date-time by default

### DIFF
--- a/src/portal/ui/viewer/jwt.cljs
+++ b/src/portal/ui/viewer/jwt.cljs
@@ -16,7 +16,8 @@
            {:portal.viewer/for
             {:auth_time :portal.viewer/date-time
              :exp :portal.viewer/date-time
-             :iat :portal.viewer/date-time}})
+             :iat :portal.viewer/date-time
+             :nbf :portal.viewer/date-time}})
          :jwt/signature
          (Base64/decodeStringToUint8Array signature)}
         {:portal.viewer/for


### PR DESCRIPTION
from the spec: [nbf's] value MUST be a number containing a NumericDate value

 https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5