### PR TITLE
Replace t/report with t/do-report

### DIFF
--- a/doc/guides/test-runner.md
+++ b/doc/guides/test-runner.md
@@ -27,14 +27,14 @@ let's go with that.
 (defn run-test [ns]
   (let [report (atom [])]
     (tap> report)
-    (with-redefs [t/report #(swap! report conj %)]
+    (with-redefs [t/do-report #(swap! report conj %)]
       (t/run-tests ns))))
 
 (run-test 'user)
 ```
 
 That's pretty much it. The key here is that you simply need to intercept values
-passed to [`clojure.test/report`](https://clojuredocs.org/clojure.test/report)
+passed to [`clojure.test/do-report`](https://clojuredocs.org/clojure.test/do-report)
 and send them directly to Portal.
 
 With the code above, you should get something like:


### PR DESCRIPTION
`clojure.core/report` is a multimethod that can't be redefined using `with-redefs`. It looks like the closest thing that we can do is to redefine a `clojure.test/do-report` which also receives all the error data.