### PR TITLE
Fix: the environment variable `PATH` might be undefined.

### DIFF
--- a/src/portal/runtime/fs.cljc
+++ b/src/portal/runtime/fs.cljc
@@ -71,7 +71,7 @@
      :cljr (exists f)))
 
 (defn paths []
-  (s/split (path) (re-pattern (separator))))
+  (s/split (or (path) "") (re-pattern (separator))))
 
 (defn find-bin [paths files]
   (first


### PR DESCRIPTION
In this case, `clojure.string/split` fails since the first argument is `nil`.

```clojure
{:clojure.main/message                                                                                                                                          
 "Execution error (NullPointerException) at java.util.regex.Matcher/getTextLength (Matcher.java:1769).\nCannot read field \"text\" because \"this\" is null\n", 
 :clojure.main/triage                                                                                                                                           
 {:clojure.error/class java.lang.NullPointerException,                                                                                                          
  :clojure.error/line 1769,                                                                                                                                     
  :clojure.error/cause                                                                                                                                          
  "Cannot read field \"text\" because \"this\" is null",                                                                                                        
  :clojure.error/symbol java.util.regex.Matcher/getTextLength,                                                                                                  
  :clojure.error/source "Matcher.java",                                                                                                                         
  :clojure.error/phase :execution},                                                                                                                             
 :clojure.main/trace                                                                                                                                            
 {:via                                                                                                                                                          
  [{:type java.lang.NullPointerException,                                                                                                                       
    :message "Cannot read field \"text\" because \"this\" is null",                                                                                             
    :at [java.util.regex.Matcher getTextLength "Matcher.java" 1769]}],                                                                                          
  :trace                                                                                                                                                        
  [[java.util.regex.Matcher getTextLength "Matcher.java" 1769]                                                                                                  
   [java.util.regex.Matcher reset "Matcher.java" 415]                                                                                                           
   [java.util.regex.Matcher <init> "Matcher.java" 252]                                                                                                          
   [java.util.regex.Pattern matcher "Pattern.java" 1134]                                                                                                        
   [java.util.regex.Pattern split "Pattern.java" 1262]                                                                                                          
   [java.util.regex.Pattern split "Pattern.java" 1335]                                                                                                          
   [clojure.string$split invokeStatic "string.clj" 225]                                                                                                         
   [clojure.string$split invoke "string.clj" 219]                                                                                                               
   [portal.runtime.fs$paths invokeStatic "fs.cljc" 74]                                                                                                          
   [portal.runtime.fs$paths invoke "fs.cljc" 73]
   [portal.runtime.browser$get_chrome_bin
    invokeStatic
    "browser.cljc"
    31]
```

A very tiny issue that I discovered by accident.

Best regards, Max

Portal is awesome :partying_face: 