### PR TITLE
Fix typing in textarea

### DIFF
--- a/src/portal/shortcuts.cljs
+++ b/src/portal/shortcuts.cljs
@@ -61,7 +61,7 @@
 
 (defn input? [log]
   (when-let [e (first log)]
-    (#{"BUTTON" "INPUT" "SELECT"}
+    (#{"BUTTON" "INPUT" "SELECT" "TEXTAREA"}
      (.. e -target -tagName))))
 
 (defn- keydown [e] (swap! log #(take 5 (conj % e))) nil)


### PR DESCRIPTION
Keyboard shortcuts interfere when typing inside textarea and certain characters can't be written.

Repro: Tap UI with textarea, focus the textarea and try to type "e y h j k l v". 

```clojure
(tap>
 (with-meta
   [:textarea]
   {:portal.viewer/default :portal.viewer/hiccup}))
```

I noticed it works correctly for text inputs, it looks like there is a code detection when inputting text to disable matching shortcuts. 

This PR also adds textarea to be detected.
