### PR TITLE
Attempt to sort sub-command windows in Portal UI

### DIFF
--- a/src/portal/ui/commands.cljs
+++ b/src/portal/ui/commands.cljs
@@ -105,6 +105,14 @@
         :reagent-render
         (fn [] [:div {:ref #(reset! el %)}])}))))
 
+(defn- try-sort
+  "Attempts to sort the given selection"
+  [coll]
+  (try
+    (sort coll)
+    (catch js/Error _
+      coll)))
+
 (defn- selector-component []
   (let [selected (r/atom #{})
         active   (r/atom 0)]
@@ -113,7 +121,7 @@
             selected? @selected
             on-close  (partial close (state/use-state))
             on-done   (:run input)
-            options   (:options input)
+            options   (try-sort (:options input))
             n         (count (:options input))
             on-select #(swap! selected (if (selected? %) disj conj) %)
             on-toggle (fn toggle-all []
@@ -328,7 +336,7 @@
           :or   {component ins/inspector}
           :as options}]
       (let [theme (theme/use-theme)
-            options (filter-options options @filter-text)
+            options (try-sort (filter-options options @filter-text))
             n (count options)
             on-close (partial close (state/use-state))
             on-select


### PR DESCRIPTION
An existing feature in Portal is that maps are automatically sorted when displayed. This sorting is very convenient for finding the data I care about. This PR attempts to sort command window options before display.

## Examples
### get (and other pick-one)
#### Before
<img width="1298" alt="image" src="https://github.com/user-attachments/assets/ab95c1d0-e125-4436-b41c-b76b17548339">

#### After
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/ed9b6705-3e36-4d94-b6d7-137b1bea5dfe">

### get-in (and other pick-in) (in VS Code)
#### Before
![image](https://github.com/user-attachments/assets/bb51e122-0ec5-4456-a384-c9898e1e9b91)

#### After
![image](https://github.com/user-attachments/assets/971ed347-0894-4919-9104-6f31f85918db)


### select-columns (and other pick-many)
#### Before
<img width="1257" alt="image" src="https://github.com/user-attachments/assets/26ad6ae5-fbf6-4cfc-8d07-6d03c36d7f59">

#### After
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/f0837c8f-20f3-464c-b371-c156ba6f4026">
