### PR TITLE
Update vega_lite.cljs

### DIFF
--- a/src/portal/ui/viewer/vega_lite.cljs
+++ b/src/portal/ui/viewer/vega_lite.cljs
@@ -5,7 +5,7 @@
             [portal.ui.viewer.vega :as vega]))
 
 ;;; :spec
-(def vega-lite-url #"https://vega\.github\.io/schema/vega-lite/v\d\.json")
+(def vega-lite-url #"https://vega\.github\.io/schema/vega-lite/v[\d\.]+\.json")
 
 (s/def ::name string?)
 (s/def ::description string?)


### PR DESCRIPTION
Updating the condition to be more flexible.

These schemas are used for altair for example:
https://vega.github.io/schema/vega-lite/v5.20.1.json

Tested with 
`https://vega.github.io/schema/vega-lite/v5.20.1.json` (match) and `https://vega.github.io/schema/vega-lite/v5.20.a1.json` (no match)