### PR TITLE
Bump plugin version to 0.63.2 and update build ranges

### DIFF
--- a/extension-intellij/gradle.properties
+++ b/extension-intellij/gradle.properties
@@ -3,16 +3,16 @@
 
 pluginGroup = djblue
 pluginName = portal
-pluginVersion = 0.63.1
+pluginVersion = 0.63.2
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 231.*
-pluginUntilBuild = 253.*
+pluginUntilBuild = 261.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions = 2023.1, 2023.2, 2023.3, 2024.1, 2024.2, 2024.3, 2025.1, 2025.2, 2025.3
+pluginVerifierIdeVersions = 2023.1, 2023.2, 2023.3, 2024.1, 2024.2, 2024.3, 2025.1, 2025.2, 2025.3, 2026.1
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC


### PR DESCRIPTION
Updated plugin version and build compatibility ranges, to make the plugin work with IntelliJ 2026.1